### PR TITLE
Remove unnecessary Documenter dependency.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,4 +2,3 @@ julia 0.7
 Compat 0.17
 Calculus
 Combinatorics 0.2.2
-Documenter

--- a/src/Hermetic.jl
+++ b/src/Hermetic.jl
@@ -2,7 +2,6 @@ module Hermetic
 import Combinatorics: doublefactorial
 import Base: *, +, ^, size, show, convert
 import Calculus: integrate
-using Documenter
 using Compat
 using LinearAlgebra
 import LinearAlgebra: rmul!


### PR DESCRIPTION
Hi, as you may know we are working on a breaking release of Documenter. Therefore, we are putting upperbounds on the packages that have Documenter as a direct dependency (https://github.com/JuliaLang/METADATA.jl/pull/19162) but I noticed that this package have a dependency on Documenter for no reason. This PR removes that.